### PR TITLE
coffee shouldn't be expected to be in /usr/local/bin

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -8,7 +8,7 @@
 	<string>#!/bin/bash
 
 echo "&lt;pre style='font-family:Menlo; font-size: 22px;'&gt;"
-/usr/local/bin/coffee -scp --no-wrap | sed 's/&lt;/\&amp;lt;/g' | sed 's/&gt;/\&amp;gt;/g'
+coffee -scp --no-wrap | sed 's/&lt;/\&amp;lt;/g' | sed 's/&gt;/\&amp;gt;/g'
 echo "&lt;/pre&gt;"</string>
 	<key>fallbackInput</key>
 	<string>document</string>

--- a/Commands/Run selected text.tmCommand
+++ b/Commands/Run selected text.tmCommand
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-/usr/local/bin/coffee -s
+coffee -s
 </string>
 	<key>input</key>
 	<string>selection</string>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -8,7 +8,7 @@
 	<string>#!/bin/bash
 
 echo "&lt;pre style='font-family:Monaco; font-size: 22px;'&gt;"
-/usr/local/bin/coffee -s
+coffee -s
 echo "&lt;/pre&gt;"</string>
 	<key>input</key>
 	<string>selection</string>


### PR DESCRIPTION
This is a simple one: If `coffee` is in `/usr/local/bin`, it should be on the PATH. But not every `coffee` that's on the PATH will be in `/usr/local/bin`. Someone going by the `npm` instructions, for instance, will add `/usr/local/share/npm/bin/` to the PATH rather than setting up an alias in `/usr/local/bin`. Therefore, the Build and Run commands should just refer to `coffee`, not `/usr/local/bin/coffee`.
