### PR TITLE
Add note on PATH to the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,8 +9,11 @@ Installation:
     cd ~/Library/Application\ Support/TextMate/Bundles
     git clone git://github.com/jashkenas/coffee-script-tmbundle CoffeeScript.tmbundle
 
+*An important note about PATH:* TextMate does not source the `PATH` variable. So, you'll have to add the paths of `coffee` and `node` to TextMate's PATH (set in Preferences -> Advanced -> Shell Variables). Also make sure that the PATH includes `/usr/bin`. Otherwise, you'll experience errors when you can use the Run and Compile commands.
+
 The bundle includes syntax highlighting, the ability to compile or evaluate CoffeeScript inline, convenient symbol listing for functions, and a number of expando snippets.
 
 Patches for additions are always welcome.
 
 ![screenshot](http://jashkenas.s3.amazonaws.com/images/coffeescript/textmate-highlighting.png)
+


### PR DESCRIPTION
So, I just spent an hour trying to figure out why I was getting `coffee: command not found` whenever I tried to build or run a CoffeeScript file. Turns out the problem was that my PATH variable in CoffeeScript had gotten reset; I'd forgotten that TextMate [doesn't source PATH](http://wiki.macromates.com/Troubleshooting/TextMateAndThePath), so unless you've installed both `coffee` and `node` to `/usr/bin`, you're going to have to dig into TextMate's preferences. Very annoying.

I think the most appropriate solution is to add a note to the installation section of the README explaining this quirk of TextMate and how to address it.
