### PR TITLE
Command for Heredoc comment

### DIFF
--- a/Commands/Insert Heredoc comment.tmCommand
+++ b/Commands/Insert Heredoc comment.tmCommand
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/usr/bin/env ruby
+
+column_number = ENV['TM_COLUMN_NUMBER']
+whitespace    = " " * (column_number.to_i - 1)
+
+print &lt;&lt;-EOS
+###
+#{whitespace}$0
+#{whitespace}###
+EOS
+</string>
+	<key>fallbackInput</key>
+	<string>line</string>
+	<key>input</key>
+	<string>none</string>
+	<key>keyEquivalent</key>
+	<string>^#</string>
+	<key>name</key>
+	<string>Insert Heredoc """ comment</string>
+	<key>output</key>
+	<string>insertAsSnippet</string>
+	<key>scope</key>
+	<string>source.coffee</string>
+	<key>uuid</key>
+	<string>68A86250-0280-11E0-A976-0800200C9A66</string>
+</dict>
+</plist>


### PR DESCRIPTION
Following up on [issue 8](https://github.com/jashkenas/coffee-script-tmbundle/issues/8): Yeah, it's annoying that the natural keyboard shortcut for inserting a block comment (Cmd+#) is already used for taking screenshots; but it's a very useful command, and I think it needs to be supported. This patch makes it use Ctrl+#. If you want consistency, you could make Ctrl the modifier for all three Heredoc thingies.

Of course, users can easily change these keyboard shortcuts themselves.
