### PR TITLE
Fixed syntax highlighting of 'Class extends Parent'

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -351,16 +351,16 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.inherited-class.coffee</string>
+					<string>keyword.control.inheritance.coffee</string>
 				</dict>
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.control.inheritance.coffee</string>
+					<string>entity.other.inherited-class.coffee</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(class\b)\s+([a-zA-Z\$_]\w+)?(\s+(extends)\s+[a-zA-Z\$_]\w*)?</string>
+			<string>(class\b)\s+([a-zA-Z\$_]\w+)?(?:\s+(extends)\s+([a-zA-Z\$_]\w*))?</string>
 			<key>name</key>
 			<string>meta.class.coffee</string>
 		</dict>


### PR DESCRIPTION
Nice work!

I've changed the pattern for classes to remove the underlines between ClassName_and_extends.
