### PR TITLE
Dots in class names

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -360,7 +360,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(class\b)\s+([a-zA-Z\$_]\w+)?(\s+(extends)\s+[a-zA-Z\$_]\w*)?</string>
+			<string>(class\b)\s+([a-zA-Z\$_][\w\.]+)?(\s+(extends)\s+[a-zA-Z\$\._][\w\.]*)?</string>
 			<key>name</key>
 			<string>meta.class.coffee</string>
 		</dict>


### PR DESCRIPTION
Tweaked the grammar file slightly to support dots in class names. E.g.

```
class ns.PlacementPeriodField extends Backbone.View
```
