### PR TITLE
changed the commands which show a web view to use the 'pre' tool

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -7,9 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-echo "&lt;pre style='font-family:Menlo; font-size: 22px;'&gt;"
-coffee -scp --bare | sed 's/&lt;/\&amp;lt;/g' | sed 's/&gt;/\&amp;gt;/g'
-echo "&lt;/pre&gt;"</string>
+coffee -scp --bare | pre</string>
 	<key>fallbackInput</key>
 	<string>document</string>
 	<key>input</key>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -7,9 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-echo "&lt;pre style='font-family:Monaco; font-size: 22px;'&gt;"
-coffee -s
-echo "&lt;/pre&gt;"</string>
+coffee -s | pre</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>


### PR DESCRIPTION
Eventually, something fancier could be done, but for now this at least escapes the & and < characters in the output of the Run command.
