### PR TITLE
Enable comment text reformatting

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -179,7 +179,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(#).*$\n?</string>
+			<string>(?:^[ \t]+)?(#).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.coffee</string>
 		</dict>


### PR DESCRIPTION
Without this patch, hitting ^Q while in the scope of a comment
(comment.line.coffee) does not reformat the whole comment to the word-wrap
column boundary like it does when in the same scope on a ruby file. Telling
TextMate to treat the whitespace before the `#` character as part of the
comment (like in the ruby grammar) fixes the issue.
