### PR TITLE
Highlight constructors with more than two dots - eg: new Foo.Bar.Baz

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -55,7 +55,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(new)\s+(\w+(?:\.\w*)?)</string>
+			<string>(new)\s+(\w+(?:\.\w*)*)</string>
 			<key>name</key>
 			<string>meta.class.instance.constructor</string>
 		</dict>


### PR DESCRIPTION
Before patch:

```
new Foo.Bar.Baz arg
    ^^^^^^^
    only this part highlighted
```

After patch:

```
new Foo.Bar.Baz arg
    ^^^^^^^^^^^
    highlight party!
```
