### PR TITLE
Function Definitions in the Symbol List

### DIFF
--- a/Preferences/Symbol List: Method 2.tmPreferences
+++ b/Preferences/Symbol List: Method 2.tmPreferences
@@ -5,13 +5,13 @@
 	<key>name</key>
 	<string>Symbol List: Method</string>
 	<key>scope</key>
-	<string>source.coffee meta.function</string>
+	<string>source.coffee meta.function.coffee</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>s/^(\s*)([a-zA-Z\$_](\w|\$|:|\.))*\s*:/$1$2/</string>
+		<string>s/^\s*([a-zA-Z\$_]+)\s*=/$2/</string>
 	</dict>
 	<key>uuid</key>
 	<string>419D24D8-0DD6-4D9A-8CA0-6D9CD740BEEC</string>

--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -299,6 +299,21 @@
 					<key>name</key>
 					<string>entity.name.function.coffee</string>
 				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.coffee</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.function.coffee</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.function.coffee</string>
+				</dict>
 			</dict>
 			<key>match</key>
 			<string>(\s*)(?=[a-zA-Z\$_])([a-zA-Z\$_](\w|\$|:|\.)*\s*(?=[:=](\s*\(.*\))?\s*((=|-)&gt;)))</string>


### PR DESCRIPTION
Adding "f = (params) ->" to scope selector and to Symbol List. Command+Shift+T now shows function definitions.
