### PR TITLE
Use pygments to print javascript source when using Cmd+B

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -7,8 +7,8 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-if type -P pygmentize &amp;&gt;/dev/null; then
-	${TM_COFFEE:=coffee} -scp --bare | pygmentize -l javascript -f html -O full,style=emacs #,linenos=1 # for line numbers
+if type -P ${TM_PYGMENTIZE:=pygmentize} &amp;&gt;/dev/null; then
+	${TM_COFFEE:=coffee} -scp --bare | ${TM_PYGMENTIZE:=pygmentize} -l javascript -f html -O full,style=emacs #,linenos=1 # for line numbers
 else
 	${TM_COFFEE:=coffee} -scp --bare | pre
 fi</string>

--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -155,7 +155,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>###</string>
+			<string>(?&lt;!#)###(?!#)</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>
@@ -165,7 +165,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>###[ \t]*\n</string>
+			<string>###(?:[ \t]*\n)</string>
 			<key>name</key>
 			<string>comment.block.coffee</string>
 			<key>patterns</key>
@@ -188,7 +188,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(#)(?!##).*$\n?</string>
+			<string>(#).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.coffee</string>
 		</dict>


### PR DESCRIPTION
If the user has pygments installed, Textmate shows the output using pygmentize command instead of "pre". If not installed, it uses `pre` as usual.

The output is a full html page with the style "emacs".
