### PR TITLE
Syntax Highlight Compiled Display

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -7,7 +7,16 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-${TM_COFFEE:=coffee} -scp --bare | pre</string>
+function highlight {
+  test `which pygmentize`
+  if [[ $? -eq 0 ]]; then
+    pygmentize -Onoclasses,nobackground=True -l js -f html
+  else
+    pre
+  fi
+}
+
+${TM_COFFEE:=coffee} -scp --bare | highlight</string>
 	<key>fallbackInput</key>
 	<string>document</string>
 	<key>input</key>


### PR DESCRIPTION
If you have the pygments command line utility installed, the command to compile and display will be syntax highlighted. Otherwise, the existing behavior remains.
