### PR TITLE
compile-and-save command

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>

--- a/Commands/Compile and Save.tmCommand
+++ b/Commands/Compile and Save.tmCommand
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>name</key>
+        <string>Compile and Save</string>
+        <key>uuid</key>
+        <string>2000D73F-02FB-4EF9-895E-02AFD1FE78B9</string>
+        <key>input</key>
+        <string>none</string>
+        <key>output</key>
+        <string>showAsTooltip</string>
+        <key>command</key>
+        <string>#!/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin:$PATH
+newfile=`echo ${TM_FILEPATH} | sed "s/\.coffee$/.js/"` 
+${TM_COFFEE:=coffee} -cp --bare ${TM_FILEPATH} &gt; $newfile
+echo Coffe `${TM_COFFEE:=coffee} -v`
+echo Coffee: "${TM_FILEPATH}"
+echo Compiled to: $newfile</string>
+        <key>beforeRunningCommand</key>
+        <string>saveActiveFile</string>
+        <key>scope</key>
+        <string>source.coffee</string>
+        <key>keyEquivalent</key>
+        <string>@^$s</string>
+    </dict>
+</plist>

--- a/Commands/Run selected text.tmCommand
+++ b/Commands/Run selected text.tmCommand
@@ -6,8 +6,10 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/bash
-
+PATH=/usr/local/bin:/usr/bin:/bin:$PATH
+echo '<pre>'
 ${TM_COFFEE:=coffee} -s
+echo '</pre>'
 </string>
 	<key>input</key>
 	<string>selection</string>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -6,8 +6,10 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/bash
-
-${TM_COFFEE:=coffee} -s | pre</string>
+PATH=/usr/local/bin:/usr/bin:/bin:$PATH
+echo '<pre>'
+${TM_COFFEE:=coffee} -s
+echo '</pre>'</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>


### PR DESCRIPTION
I've merged the compile and save command from https://github.com/palpha/coffee-script-tmbundle/commit/43c933d527428dec975a6cfe7b4a6613a3eaee8d .This also includes e compatibility fixes by the same author that do not seem to break TextMate compatibility, although I cannot check that my merge did not break it for e, as I don't have that editor.

Not sure about the placing of the "compile and save" command in the root menu - I guess it's either "run" or "other", but didn't know which to pick.
