### PR TITLE
"Compile and Display JS" command: show line numbers!

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -10,7 +10,7 @@
 function highlight {
   test `which pygmentize`
   if [[ $? -eq 0 ]]; then
-    pygmentize -Onoclasses,nobackground=True -l js -f html
+    pygmentize -Onoclasses,nobackground=True,linenos=1 -l js -f html
   else
     pre
   fi


### PR DESCRIPTION
We love this command -- it's extremely useful for validating quick snippets of Coffee -- but it always made us sad when we got an error in our JS and we had no easy way of seeing the generated JS line at the error's line number. So we added line numbers to this command's output; now we can quickly "Compile and Display JS" to see which generated line is causing the error!

Found the option through the sort-of-light documentation on `pygmentize`: http://pygments.org/docs/cmdline/

Thanks @jashkenas for this excellent bundle!
