### PR TITLE
recognize hashbang signature

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -9,6 +9,8 @@
 		<string>coffee</string>
 		<string>Cakefile</string>
 	</array>
+	<key>firstLineMatch</key>
+	<string>^#!.*\bcoffee</string>
 	<key>foldingStartMarker</key>
 	<string>.*(-&gt;|=&gt;)\s*$|.*[\[{]\s*$</string>
 	<key>foldingStopMarker</key>


### PR DESCRIPTION
recognize hashbang signature so that a script file without extension still gets recognized as coffee-script if the hashbang ends with the word coffee.
