### PR TITLE
Minor cleanup in require snippet

### DIFF
--- a/Snippets/require.tmSnippet
+++ b/Snippets/require.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>${2/^.*?([\w_]+).*$/\L$1/}= require(${2:'${1:sys}'})</string>
+	<string>${2/^.*?([\w_]+).*$/\L$1/} = require ${2:'${1:sys}'}$3</string>
 	<key>name</key>
 	<string>require</string>
 	<key>scope</key>


### PR DESCRIPTION
Make the require snippet fit proper spacing (space after equals), not use parens, and let the user tab again to get to the end of the current line to hit enter if they want.
