### PR TITLE
"Compile and Display JS" command: re-add line numbers. 

### DIFF
--- a/Commands/Compile and Display JS.tmCommand
+++ b/Commands/Compile and Display JS.tmCommand
@@ -10,7 +10,7 @@
 function highlight {
   test `which pygmentize`
   if [[ $? -eq 0 ]]; then
-    pygmentize -Onoclasses,nobackground=True,style=autumn,encoding=utf8 -l js -f html
+    pygmentize -Onoclasses,nobackground=True,style=autumn,linenos=1,encoding=utf8 -l js -f html
   else
     pre
   fi


### PR DESCRIPTION
Original commit that did this: 6c4191eca1f30388ce19a7b75a0f4b8df02a3cb8

Seemed to have been overwritten: 49a55aac5d2d5fd857c78b5b6850c3a4c3f8f9d3

Hope this is accepted again -- it's super useful to see the line numbers when debugging stack traces. =) Thanks!
