### PR TITLE
A small change request for highlighting of class definitions inside modules

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -387,7 +387,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(class\b)\s+([a-zA-Z\$_][\w\.]+)?(?:\s+(extends)\s+([a-zA-Z\$\._][\w\.]*))?</string>
+			<string>(class\b)\s+([a-zA-Z\$_@][\w\.]+)?(?:\s+(extends)\s+([a-zA-Z\$\._][\w\.]*))?</string>
 			<key>name</key>
 			<string>meta.class.coffee</string>
 		</dict>


### PR DESCRIPTION
support @ in class names in class definitions when defining classes in modules like described here https://github.com/jashkenas/coffee-script/wiki/Easy-modules-with-coffeescript
