### PR TITLE
Updated Language Grammar to include comment symbol specification in scope

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -193,7 +193,7 @@
 			<key>match</key>
 			<string>(#).*$\n?</string>
 			<key>name</key>
-			<string>comment.line.coffee</string>
+			<string>comment.line.number-sign.coffee</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -517,7 +517,7 @@
 					<key>match</key>
 					<string>(?&lt;!\\)(#).*$\n?</string>
 					<key>name</key>
-					<string>comment.line.coffee</string>
+					<string>comment.line.number-sign.coffee</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Updated Language Grammar scope from "comment.line.coffee" to "comment.line.number-sign.coffee"

The scope for a single line comment symbol is used by the TextMate Source bundle command 'Continue Line Comment'.  Without specifying the symbol in the scope, the command does not function.  Changing "comment.line.coffee" to "comment.line.number-sign.coffee" allows this command to be used with CoffeeScript.
