### PR TITLE
New web_server.coffee screenshot using util instead of sys.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ The bundle includes syntax highlighting, the ability to compile or evaluate Coff
 
 Patches for additions are always welcome.
 
-![screenshot](http://jashkenas.s3.amazonaws.com/images/coffeescript/textmate-highlighting.png)
+![screenshot](http://i.imgur.com/ob8GP.png)
 
 If your TextMate.app is having trouble finding the `coffee` command, remember that [TextMate doesn't inherit your regular PATH](http://wiki.macromates.com/Troubleshooting/TextMateAndThePath). 
 


### PR DESCRIPTION
sys appears deprecated (see below), so I created a new screenshot requiring util
instead.

$ node

> require('sys');
> The "sys" module is now called "util". It should have a similar
> interface.
> 2
