### PR TITLE
Folding ### comment blocks

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -13,9 +13,9 @@
 	<key>firstLineMatch</key>
 	<string>^#!.*\bcoffee</string>
 	<key>foldingStartMarker</key>
-	<string>^\s*class\s+\S.*$|.*(-&gt;|=&gt;)\s*$|.*[\[{]\s*$</string>
+	<string>^\s*class\s+\S.*$|.*(-&gt;|=&gt;)\s*$|.*[\[{]\s*$|###\*.*$</string>
 	<key>foldingStopMarker</key>
-	<string>^\s*$|^\s*[}\]]\s*$</string>
+	<string>^\s*$|^\s*[}\]]\s*$|\*###.*$</string>
 	<key>keyEquivalent</key>
 	<string>^~C</string>
 	<key>name</key>


### PR DESCRIPTION
The starting pattern of ###\* and the ending pattern *### folds the comment block in the editor. 
