### PR TITLE
Preserve coffeescript interpolation in haml templates

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -191,7 +191,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(#).*$\n?</string>
+			<string>(#)(?!\{).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.number-sign.coffee</string>
 		</dict>


### PR DESCRIPTION
Added lookahead for { in order to distinguish comments from CoffeeScript interpolation in HAML templates.

For instance in

  some haml

  :coffeescript
    some coffeescript #{ insert content in haml template } some more coffeescript

the last line is not displayed as a comment appended to some coffeescript any more.
