### PR TITLE
Added info and sample settings for Windows users.

### DIFF
--- a/Commands/CoffeeScript.sublime-build
+++ b/Commands/CoffeeScript.sublime-build
@@ -3,4 +3,17 @@
 	"cmd": ["coffee","-c","$file"],
 	"file_regex": "^(...*?):([0-9]*):?([0-9]*)",
 	"selector": "source.coffee"
+
+/*
+     Windows users: use these settings.
+
+     The path will work OK with the default node.js + 
+     npm coffee-script installation. Alternatively,
+     adjust the path to the CoffeeScript executable.
+
+	"cmd": ["coffee.cmd", "-c", "$file"],
+	"file_regex": "^(...*?):([0-9]*):?([0-9]*)",
+	"selector": "source.coffee"
+
+*/
 }


### PR DESCRIPTION
Not sure if there is better way for ST2 packages to work seamlessly on both *NIX and Windows but for starters I've added a comment and sample settings into the CoffeeScript.sublime-build file.
