### PR TITLE
I am not sure exactly which release of Textmate 1.x moved the location o...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Installation:
 -------------
 
     cd ~/Library/Application\ Support/TextMate/Bundles (Textmate 1)
-    cd /Applications/TextMate.app/Contents/SharedSupport/Bundles (Textmate 2)
+    cd /Applications/TextMate.app/Contents/SharedSupport/Bundles (Textmate 1.5.10 & 2)
     git clone git://github.com/jashkenas/coffee-script-tmbundle CoffeeScriptBundle.tmbundle
 
 The bundle includes syntax highlighting, the ability to compile or evaluate CoffeeScript inline, convenient symbol listing for functions, and a number of expando snippets.


### PR DESCRIPTION
...f the bundles directory. However, in version 1.5.10 the bundles have been moved to /Applications/TextMate.app/Contents/SharedSupport/Bundles.
