### PR TITLE
Fix the build file so that it works better on Windows

### DIFF
--- a/Commands/CoffeeScript.sublime-build
+++ b/Commands/CoffeeScript.sublime-build
@@ -3,4 +3,9 @@
 	"cmd": ["coffee","-c","$file"],
 	"file_regex": "^(...*?):([0-9]*):?([0-9]*)",
 	"selector": "source.coffee"
+
+	"windows":
+	{
+		"cmd": ["coffee.cmd","-c","$file"]
+	}
 }


### PR DESCRIPTION
Hi,

The build file wasn't working on my Windows environment, using Sublime Text 2.

According to what I saw here:
http://sublimetext.info/docs/en/reference/build_systems.html
We have to add an extension to the executable so that it works better, so I added a part in the build file to make it work better on Windows, it works on my environment and it shouldn't have any impact on the execution on Linux or Mac OS because the "windows" part should be used only on Windows. It would be great  if someone could test it on a Unix and Mac OS environment, unfortunately, I can't.

Thanks !
