### PR TITLE
Fix highlighting of bounded functions in callbacks.

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -261,7 +261,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([a-zA-Z\$_](\w|\$|\.)*\s*(?!\::)((:)|(=))(?!(\s*\(.*\))?\s*((=|-)&gt;)))</string>
+			<string>([a-zA-Z\$_](\w|\$|\.)*\s*(?!\::)((:)|(=)(?!&gt;))(?!(\s*\(.*\))?\s*([=-]&gt;)))</string>
 			<key>name</key>
 			<string>variable.assignment.coffee</string>
 		</dict>


### PR DESCRIPTION
`a =>` was highlightened as `a <operator>`.
