### PR TITLE
Improve pasting indent expectations with indentOnPaste setting.

### DIFF
--- a/Preferences/Disable Indent Corrections.tmPreferences
+++ b/Preferences/Disable Indent Corrections.tmPreferences
@@ -10,6 +10,8 @@
 	<dict>
 		<key>disableIndentCorrections</key>
 		<true/>
+		<key>indentOnPaste</key>
+		<string>simple</string>
 	</dict>
 	<key>uuid</key>
 	<string>5E57C0C3-77D5-4809-A131-F777EE264908</string>


### PR DESCRIPTION
This improves how TextMate handles indenting in indent-based languages. With the `simple` setting it will indent the paste to the position of the caret.

(Read more in the release notes inside TextMate.)
