### PR TITLE
Increase indentation after `else` keyword

### DIFF
--- a/Preferences/Indent.tmPreferences
+++ b/Preferences/Indent.tmPreferences
@@ -16,7 +16,7 @@
 		(.*class
 		|[a-zA-Z\$_](\w|\$|:|\.)*\s*(?=\:(\s*\(.*\))?\s*((=|-)&gt;\s*$)) # function that is not one line
 		|[a-zA-Z\$_](\w|\$|\.)*\s*(:|=)\s*((if|while)(?!.*?then)|for|$) # assignment using multiline if/while/for
-		|(if|while)\b(?!.*?then)|for\b
+		|(if|else|while)\b(?!.*?then)|for\b
 		|(try|finally|catch\s+\S.*)\s*$
 		|.*[-=]&gt;$
 		|.*[\{\[]$)</string>


### PR DESCRIPTION
I'm not sure if there's a reason why the `else` keyword isn't increasing indentation of the next line, but I find it convenient. Maybe I'm missing some evil corner-case.
