### PR TITLE
proper interpolated comment highlight

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -645,7 +645,7 @@
 					<key>end</key>
 					<string>\}</string>
 					<key>name</key>
-					<string>source.coffee.embedded.source</string>
+					<string>meta.embedded.line.coffee</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
themes usually use `meta.embedded.line.*` to identify interpolated source within a string. i.e. in a scenario like `alert("the value is: #{value}")`, some themes (like Twilight) apply a background highlight on the `#{value}` section if using that prefix.
