### PR TITLE
Add .coffee.md to fileTypes for CoffeeScript (Literate)

### DIFF
--- a/Syntaxes/CoffeeScript (Literate).tmLanguage
+++ b/Syntaxes/CoffeeScript (Literate).tmLanguage
@@ -8,6 +8,7 @@
 	<array>
 		<string>litcoffee</string>
 		<string>litcoffee.erb</string>
+		<string>coffee.md</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(?x)


### PR DESCRIPTION
Files with the `.coffee.md` extension are automatically highlighted as CoffeeScript (literate). Tested in TextMate 1.5.11 on Mac OS X 10.7.5
