### PR TITLE
Fixes #131. Change scope type to text.

### DIFF
--- a/Syntaxes/CoffeeScript (Literate).tmLanguage
+++ b/Syntaxes/CoffeeScript (Literate).tmLanguage
@@ -1814,7 +1814,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.litcoffee</string>
+	<string>text.litcoffee</string>
 	<key>uuid</key>
 	<string>70456B1D-AC94-4E9B-81AB-426F0D1ACB86</string>
 </dict>


### PR DESCRIPTION
It seems Sublime Text 2 have a habit of pushing subsequent lines of wrapped **code** one indentation level to the right. It does not do this with **text** (as opposed to code). Whether scope is considered code or text depends on `scopeName` property. If it starts with `source.` - then it's code. If it starts with `text.` - then it's text. Probably it would be better to make prose text and code - code, but I don't know how to.

I think this change makes sense in a way. In literate programming we focus on prose. So it's more text then source... Kinda :)

EDIT: Sorry. I thought if I name my commit like that it will be attached to #131 . Can this be merged with it?
