### PR TITLE
Use look-behind for whitespace before functions

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -315,6 +315,11 @@
 		<dict>
 			<key>captures</key>
 			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.coffee</string>
+				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
@@ -323,14 +328,9 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.coffee</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
 					<string>variable.parameter.function.coffee</string>
 				</dict>
-				<key>5</key>
+				<key>4</key>
 				<dict>
 					<key>name</key>
 					<string>storage.type.function.coffee</string>
@@ -338,7 +338,7 @@
 			</dict>
 			<key>match</key>
 			<string>(?x)
-				(\s*)
+				(?<=^|\s)
 				(?=[a-zA-Z\$_])
 				(
 					[a-zA-Z\$_](\w|\$|:|\.)*\s*


### PR DESCRIPTION
This will no longer capture the whitespace leading up to a function name.
