### PR TITLE
Allow injection grammars in comments

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -182,7 +182,9 @@
 			</array>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>(#)(?!\{)</string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -190,8 +192,8 @@
 					<string>punctuation.definition.comment.coffee</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(#)(?!\{).*$\n?</string>
+			<key>end</key>
+			<string>\n</string>
 			<key>name</key>
 			<string>comment.line.number-sign.coffee</string>
 		</dict>


### PR DESCRIPTION
Using a begin/end pattern for single line comments allows injection grammars such as TODO and hyperlinks to highlight in comments.
### Before

![screen shot 2013-08-31 at 10 40 18 am](https://f.cloud.github.com/assets/671378/1062689/268b0696-1265-11e3-9041-c9632ffe2545.png)
### After

![screen shot 2013-08-31 at 10 43 26 am](https://f.cloud.github.com/assets/671378/1062690/30461662-1265-11e3-97eb-2b82cd2be1bb.png)
