### PR TITLE
Properly handle backslashes in regexes

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -218,7 +218,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>/(?![\s=/*+{}?]).*?[^\\]/[igmy]{0,4}(?![a-zA-Z0-9])</string>
+			<string>/(?![\s=/*+{}?])(\\.|.)*?/[igmy]{0,4}(?![a-zA-Z0-9])</string>
 			<key>name</key>
 			<string>string.regexp.coffee</string>
 		</dict>


### PR DESCRIPTION
Noticed an issue when having a regex of just `/\\/`.
### Before

![screen shot 2013-11-02 at 7 01 58 pm](https://f.cloud.github.com/assets/671378/1460340/514b6878-442c-11e3-9e89-17f982307874.png)
### After

![screen shot 2013-11-02 at 7 06 04 pm](https://f.cloud.github.com/assets/671378/1460345/9bc4a34c-442c-11e3-9bb1-04349f4fa10a.png)
