### PR TITLE
Indent after switch and when statements

### DIFF
--- a/Preferences/Indent.tmPreferences
+++ b/Preferences/Indent.tmPreferences
@@ -16,8 +16,8 @@
 		(.*class
 		|[a-zA-Z\$_](\w|\$|:|\.)*\s*(?=\:(\s*\(.*\))?\s*((=|-)&gt;\s*$)) # function that is not one line
 		|[a-zA-Z\$_](\w|\$|\.)*\s*(:|=)\s*((if|while)(?!.*?then)|for|$) # assignment using multiline if/while/for
-		|(if|else|unless|while)\b(?!.*?then)|for|loop\b
-		|(try|finally|catch\s+\S.*)\s*$
+		|(if|else|unless|while|when)\b(?!.*?then)|for|loop\b
+		|(try|finally|catch|switch\s+\S.*)\s*$
 		|.*[-=]&gt;$
 		|.*[\{\[]$)</string>
 	</dict>


### PR DESCRIPTION
Mirrors the example [here](http://coffeescript.org/#switch) to indent after switch and when statements.
